### PR TITLE
add swiftype version meta tag to page template

### DIFF
--- a/mule-docs-builder/src/main/java/com/mulesoft/documentation/builder/Page.java
+++ b/mule-docs-builder/src/main/java/com/mulesoft/documentation/builder/Page.java
@@ -62,7 +62,7 @@ public class Page {
         html = Utilities.replaceText(html, "{{ page.version-notification }}", getVersionNotificationHtml(sections, section, sectionVersions, page));
         html = Utilities.replaceText(html, "{{ page.sections }}", getSectionNavigator(page));
         html = Utilities.replaceText(html, "{{ page.metadata }}", getPageMetadata(page));
-        html = Utilities.replaceText(html, "{{ page.swifttype-metadata }}", getSwiftTypeMetadata(page));
+        html = Utilities.replaceText(html, "{{ page.swifttype-metadata }}", getSwiftypeMetadata(section, page));
         html = Utilities.replaceText(html, "{{ page.github-link }}", getGitHubRepoUrl(section, page, gitHubRepoUrl, gitHubBranchName));
         html = Utilities.replaceText(html, "{{ page.canonical }}", getCanonicalUrlText(siteRootUrl, section, page));
 
@@ -119,8 +119,8 @@ public class Page {
         return PageMetadata.fromAsciiDocPage(page);
     }
 
-    private static String getSwiftTypeMetadata(AsciiDocPage page) {
-        return SwiftTypeMetadata.fromAsciiDocPage(page);
+    private static String getSwiftypeMetadata(Section section, AsciiDocPage page) {
+        return SwiftypeMetadata.fromAsciiDocPage(section, page);
     }
 
     // FIXME move this method to the VersionSelector

--- a/mule-docs-builder/src/main/java/com/mulesoft/documentation/builder/PageMetadata.java
+++ b/mule-docs-builder/src/main/java/com/mulesoft/documentation/builder/PageMetadata.java
@@ -7,7 +7,6 @@ import org.slf4j.LoggerFactory;
  * Created by sean.osterberg on 7/6/15.
  */
 public class PageMetadata {
-
     private static Logger logger = LoggerFactory.getLogger(PageMetadata.class);
 
     public static String fromAsciiDocPage(AsciiDocPage page) {
@@ -16,19 +15,11 @@ public class PageMetadata {
 
     public static String getMetadataEntries(AsciiDocPage page) {
         logger.debug("Creating metadata for page \"" + page.getTitle() + "\"...");
-        String result = "";
-        result += getBodyMetadata(page);
-        return result;
+        return getBodyMetadata(page);
     }
 
     public static String getBodyMetadata(AsciiDocPage page) {
-        String bodyText = SwiftTypeMetadata.getDescription(page);
-        if (bodyText.length() > 0) {
-            String result = "<meta name=\"description\" content=";
-            result += "\"" + bodyText + "\" />";
-            return result;
-        }
-        return "";
+        String bodyText = SwiftypeMetadata.getDescription(page);
+        return bodyText.isEmpty() ? "" : "<meta name=\"description\" content=\"" + bodyText + "\" />";
     }
-
 }

--- a/mule-docs-builder/src/main/java/com/mulesoft/documentation/builder/Section.java
+++ b/mule-docs-builder/src/main/java/com/mulesoft/documentation/builder/Section.java
@@ -74,7 +74,19 @@ public class Section {
     public String getBaseName() {
         return baseName;
     }
+    
+    public SectionVersion getSectionVersion() {
+        return sectionVersion;
+    }
 
+    public boolean isRoot() {
+        return baseName.isEmpty();
+    }
+    
+    public boolean isVersionless() {
+        return versionPrettyName.equals("latest");
+    }
+    
     public boolean containsPageMatching(AsciiDocPage page) {
         // in this case, the section has the same version as the page
         if (getPages().contains(page)) {
@@ -89,14 +101,6 @@ public class Section {
             }
         }
         return false;
-    }
-
-    public boolean isRoot() {
-        return baseName.isEmpty();
-    }
-
-    public SectionVersion getSectionVersion() {
-        return sectionVersion;
     }
 
     public static Section fromDirectoryAndSectionVersion(File directory, SectionVersion sectionVersion) {

--- a/mule-docs-builder/src/main/java/com/mulesoft/documentation/builder/SwiftypeMetadata.java
+++ b/mule-docs-builder/src/main/java/com/mulesoft/documentation/builder/SwiftypeMetadata.java
@@ -13,37 +13,37 @@ import org.slf4j.LoggerFactory;
 /**
  * Created by sean.osterberg on 7/5/15.
  */
-public class SwiftTypeMetadata {
-    private static Logger logger = LoggerFactory.getLogger(SwiftTypeMetadata.class);
+public class SwiftypeMetadata {
+    private static Logger logger = LoggerFactory.getLogger(SwiftypeMetadata.class);
 
-    public static String fromAsciiDocPage(AsciiDocPage page) {
-        return getMetadataEntries(page);
+    public static String fromAsciiDocPage(Section section, AsciiDocPage page) {
+        return getMetadataEntries(section, page);
     }
 
-    public static String getMetadataEntries(AsciiDocPage page) {
-        logger.debug("Creating SwiftType metadata for page \"" + page.getTitle() + "\"...");
-        String result = "";
-        result += getTitleMetadata(page);
-        // result += getBodyMetadata(page);
+    public static String getMetadataEntries(Section section, AsciiDocPage page) {
+        logger.debug("Creating Swiftype metadata for page \"" + page.getTitle() + "\"...");
+        String result = getTitleMetadata(page);
+        String versionMetadata = getVersionMetadata(section);
+        if (!versionMetadata.isEmpty()) {
+            result += "\n    " + versionMetadata;
+        }
         return result;
     }
 
     public static String getTitleMetadata(AsciiDocPage page) {
-        String result = "<meta class=\"swiftype\" name=\"title\" data-type=\"string\" content=";
-        result += "\"" + page.getTitle().trim() + "\" />\n";
-        return result;
+        return "<meta class=\"swiftype\" name=\"title\" data-type=\"string\"" +
+            " content=\"" + page.getTitle().trim() + "\" />";
     }
 
-    public static String getBodyMetadata(AsciiDocPage page) {
-        String bodyText = getDescription(page);
-        if (bodyText.length() > 0) {
-            String result = "    <meta class=\"swiftype\" name=\"body\" data-type=\"text\" content=";
-            result += "\"" + bodyText + "\" />\n";
-            return result;
+    public static String getVersionMetadata(Section section) {
+        if (section.isRoot() || section.isVersionless()) {
+            return "";
         }
-        return "";
+        
+        return "<meta class=\"swiftype\" name=\"version\" data-type=\"string\"" +
+            " content=\"" + section.getVersionPrettyName() + "\" />";
     }
-
+    
     public static String getDescription(AsciiDocPage page) {
         String result = "";
         Document doc = Jsoup.parse(page.getHtml(), "UTF-8");
@@ -86,5 +86,4 @@ public class SwiftTypeMetadata {
 
         return text;
     }
-
 }

--- a/mule-docs-builder/src/main/java/com/mulesoft/documentation/builder/model/SectionVersion.java
+++ b/mule-docs-builder/src/main/java/com/mulesoft/documentation/builder/model/SectionVersion.java
@@ -46,4 +46,8 @@ public class SectionVersion {
     public boolean isRoot() {
         return sectionBaseName.isEmpty();
     }
+    
+    public boolean isVersionless() {
+        return versionName.equals("latest");
+    }
 }

--- a/mule-docs-builder/src/test/java/com/mulesoft/documentation/builder/SwiftypeMetadataTest.java
+++ b/mule-docs-builder/src/test/java/com/mulesoft/documentation/builder/SwiftypeMetadataTest.java
@@ -1,32 +1,35 @@
 package com.mulesoft.documentation.builder;
 
+import com.mulesoft.documentation.builder.model.SectionVersion;
 import com.mulesoft.documentation.builder.util.Utilities;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Created by sean.osterberg on 7/5/15.
  */
-public class SwiftTypeMetadataTest {
+public class SwiftypeMetadataTest {
 
     @Test
     public void getDescription_ReturnsExpectedResult() {
-        String result = SwiftTypeMetadata.getDescription(getValidAsciiDocPage());
+        String result = SwiftypeMetadata.getDescription(getValidAsciiDocPage());
         assertEquals(result, "Integrate SaaS applications, Cloud Services and Enterprise applications in real-time. CloudHub is the world’s first integration Platform as a Servi...");
     }
 
     @Test
     public void getFirstParagraph_EndsWithEllipses() {
-        String result = SwiftTypeMetadata.getDescription(getValidAsciiDocPage());
+        String result = SwiftypeMetadata.getDescription(getValidAsciiDocPage());
         assertTrue(result.endsWith("..."));
     }
 
     @Test
     public void getFirstParagraph_WithFewerThan147Chars_ReturnsExpectedResult() {
-        String result = SwiftTypeMetadata.getDescription(getValidAsciiDocPage());
+        String result = SwiftypeMetadata.getDescription(getValidAsciiDocPage());
         assertTrue(result.endsWith("..."));
     }
 
@@ -34,30 +37,43 @@ public class SwiftTypeMetadataTest {
     public void getFirstParagraph_WithAdmonition_ReturnsTextFromAdmonition() {
         String path = Utilities.getConcatPath(new String[]{TestUtilities.getPathToMasterFolder(), "cloudhub", "v", "4.0", "deploying-a-cloudhub-application.adoc"});
         AsciiDocPage page = AsciiDocPage.fromFile(new File(path));
-        String result = SwiftTypeMetadata.getDescription(page);
-        assertTrue(result.equals("You can deploy an application to CloudHub directly from Anypoint™ Studio, or you can deploy it using the CloudHub console. This page covers deploym..."));
+        String result = SwiftypeMetadata.getDescription(page);
+        assertTrue(result.equals("To deploy a CloudHub application, you simply upload it to CloudHub and the platform automatically deploys your application.  You can deploy an..."));
     }
 
     @Test
     public void getFirstParagraph_WithLongParagraph_ReturnsExpectedResult() {
         String path = Utilities.getConcatPath(new String[]{TestUtilities.getPathToMasterFolder(), "cloudhub", "v", "4.0", "index.adoc"});
         AsciiDocPage page = AsciiDocPage.fromFile(new File(path));
-        String result = SwiftTypeMetadata.getDescription(page);
+        String result = SwiftypeMetadata.getDescription(page);
         assertEquals(result, "Integrate SaaS applications, Cloud Services and Enterprise applications in real-time. CloudHub is the world’s first integration Platform as a Servi...");
     }
 
     @Test
     public void getTitleMetadata_ReturnsExpectedResult() {
-        String result = SwiftTypeMetadata.getTitleMetadata(getValidAsciiDocPage());
-        assertTrue(result.equals("<meta class=\"swiftype\" name=\"title\" data-type=\"string\" content=\"CloudHub\" />\n"));
+        String result = SwiftypeMetadata.getTitleMetadata(getValidAsciiDocPage());
+        assertTrue(result.equals("<meta class=\"swiftype\" name=\"title\" data-type=\"string\" content=\"CloudHub\" />"));
     }
 
     @Test
     public void getTitleMetadata_WithLongTitle_ReturnsExpectedResult() {
         String path = Utilities.getConcatPath(new String[]{TestUtilities.getPathToMasterFolder(), "cloudhub", "v", "4.0", "deploying-a-cloudhub-application.adoc"});
         AsciiDocPage page = AsciiDocPage.fromFile(new File(path));
-        String result = SwiftTypeMetadata.getTitleMetadata(page);
-        assertTrue(result.equals("<meta class=\"swiftype\" name=\"title\" data-type=\"string\" content=\"Deploying a CloudHub Application\" />\n"));
+        String result = SwiftypeMetadata.getTitleMetadata(page);
+        assertTrue(result.equals("<meta class=\"swiftype\" name=\"title\" data-type=\"string\" content=\"Deploying a CloudHub Application\" />"));
+    }
+    
+    @Test
+    public void getVersionMetadata_ReturnsExpectedResult() {
+        String result = SwiftypeMetadata.getVersionMetadata(getValidSection());
+        assertTrue(result.equals("<meta class=\"swiftype\" name=\"version\" data-type=\"string\" content=\"4.0\" />"));
+    }
+    
+    private Section getValidSection() {
+        SectionVersion version = new SectionVersion("Anypoint Platform for APIs", "cloudhub", "/cloudhub/v/4.0", "4.0", true);
+        List<AsciiDocPage> pages = new ArrayList<>();
+        pages.add(getValidAsciiDocPage());
+        return new Section(pages, null, getValidFile().getParent(), version.getVersionUrl(), version.getSectionPrettyName(), version.getVersionName(), version.getSectionBaseName(), version);
     }
 
     private AsciiDocPage getValidAsciiDocPage() {


### PR DESCRIPTION
- add swiftype version meta tag to page template if section is versioned
- add test for swiftype version meta tag
- rename SwiftType to Swiftype
- cleanup, format, and optimize code