### PR TITLE
fix the canonical URL in the HTML head

### DIFF
--- a/mule-docs-builder/src/main/java/com/mulesoft/documentation/builder/AsciiDocPage.java
+++ b/mule-docs-builder/src/main/java/com/mulesoft/documentation/builder/AsciiDocPage.java
@@ -129,5 +129,8 @@ public class AsciiDocPage {
         return baseName.equals("index") ? "" : baseName;
     }
 
+    public boolean isIndex() {
+        return baseName.equals("index");
+    }
 }
 

--- a/mule-docs-builder/src/main/java/com/mulesoft/documentation/builder/Page.java
+++ b/mule-docs-builder/src/main/java/com/mulesoft/documentation/builder/Page.java
@@ -149,23 +149,17 @@ public class Page {
     }
 
     private static String getCanonicalUrlText(String siteRootUrl, Section section, AsciiDocPage page) {
-        if(!section.getVersionPrettyName().equals("latest")) {
-            String relativeUrl;
-            if(!page.getBaseName().equals("index")) {
-                relativeUrl = Utilities.getConcatPath(new String[] { section.getBaseName(), "v", section.getVersionPrettyName(), page.getBaseName() });
-            } else {
-                relativeUrl = Utilities.getConcatPath(new String[] { section.getBaseName(), "v", section.getVersionPrettyName() });
-            }
-            return "<link rel=\"canonical\" href=\"" + Utilities.getConcatPath(new String[] { siteRootUrl, relativeUrl }) + "\" />";
-        } else {
-            String relativeUrl;
-            if(!page.getBaseName().equals("index")) {
-                relativeUrl = Utilities.getConcatPath(new String[] { section.getBaseName(), page.getBaseName() });
-            } else {
-                relativeUrl = section.getBaseName();
-            }
-            return "<link rel=\"canonical\" href=\"" + Utilities.getConcatPath(new String[] { siteRootUrl, relativeUrl }) + "\" />";
+        String canonicalUrl = null;
+        if (section.isSiteRoot()) {
+            canonicalUrl = siteRootUrl;
         }
+        else if (section.isVersionless()) {
+            canonicalUrl = Utilities.getConcatPath(new String[] { siteRootUrl, section.getBaseName(), page.getRelativeUrl() });
+        }
+        else {
+            canonicalUrl = Utilities.getConcatPath(new String[] { siteRootUrl, section.getBaseName(), "v", section.getVersionPrettyName(), page.getRelativeUrl() });
+        }
+        return "<link rel=\"canonical\" href=\"" + canonicalUrl + "\" />";
     }
 
     private static String getSectionNavigator(AsciiDocPage page) {

--- a/mule-docs-builder/src/main/java/com/mulesoft/documentation/builder/Section.java
+++ b/mule-docs-builder/src/main/java/com/mulesoft/documentation/builder/Section.java
@@ -79,7 +79,7 @@ public class Section {
         return sectionVersion;
     }
 
-    public boolean isRoot() {
+    public boolean isSiteRoot() {
         return baseName.isEmpty();
     }
     

--- a/mule-docs-builder/src/main/java/com/mulesoft/documentation/builder/SwiftypeMetadata.java
+++ b/mule-docs-builder/src/main/java/com/mulesoft/documentation/builder/SwiftypeMetadata.java
@@ -36,7 +36,7 @@ public class SwiftypeMetadata {
     }
 
     public static String getVersionMetadata(Section section) {
-        if (section.isRoot() || section.isVersionless()) {
+        if (section.isSiteRoot() || section.isVersionless()) {
             return "";
         }
         

--- a/mule-docs-builder/src/main/java/com/mulesoft/documentation/builder/VersionSelector.java
+++ b/mule-docs-builder/src/main/java/com/mulesoft/documentation/builder/VersionSelector.java
@@ -35,7 +35,7 @@ public class VersionSelector {
         String[] orderOfVersions = new String[versionLinkMapping.size()];
 
         // special for site index page
-        if (section.isRoot()) {
+        if (section.isSiteRoot()) {
             return "";
         // Check if the size is bigger than 0 and the version name isn't "latest", which is the default name
         }
@@ -114,7 +114,7 @@ public class VersionSelector {
 
     public Map<String, String> getVersionLinkMapping(AsciiDocPage page) {
         // root section (aka space) has no versions, so just return
-        if (sectionVersions.size() == 1 && sectionVersions.get(0).isRoot()) {
+        if (sectionVersions.size() == 1 && sectionVersions.get(0).isSiteRoot()) {
             return Collections.<String, String>emptyMap();
         }
 

--- a/mule-docs-builder/src/main/java/com/mulesoft/documentation/builder/model/SectionVersion.java
+++ b/mule-docs-builder/src/main/java/com/mulesoft/documentation/builder/model/SectionVersion.java
@@ -43,7 +43,7 @@ public class SectionVersion {
         return latestVersion;
     }
 
-    public boolean isRoot() {
+    public boolean isSiteRoot() {
         return sectionBaseName.isEmpty();
     }
     

--- a/mule-docs-builder/src/test/java/com/mulesoft/documentation/builder/UtilitiesTest.java
+++ b/mule-docs-builder/src/test/java/com/mulesoft/documentation/builder/UtilitiesTest.java
@@ -1,20 +1,20 @@
 package com.mulesoft.documentation.builder;
 
-import com.mulesoft.documentation.builder.model.TocNode;
-import com.mulesoft.documentation.builder.util.Utilities;
-import org.apache.commons.lang3.StringUtils;
-
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import com.mulesoft.documentation.builder.model.TocNode;
+import com.mulesoft.documentation.builder.util.Utilities;
 
 /**
  * Created by sean.osterberg on 2/20/15.
@@ -152,7 +152,7 @@ public class UtilitiesTest {
         sampleText.add(1, "Lorem ipsum dolor sit amet, consectetur adipiscing elit.");
         String sampleFilePath = Utilities.getConcatPath(new String[] { TestUtilities.getTestResourcesPath(), "text-files" });
         File[] sampleFiles = new File(sampleFilePath).listFiles();
-        List<File> filesInSampleDirectory = filesInSampleDirectory = Arrays.asList(sampleFiles);
+        List<File> filesInSampleDirectory = Arrays.asList(sampleFiles);
         List<String> fileText = Utilities.getFileContentsFromFiles(filesInSampleDirectory);
         for (int i = 0; i < fileText.size(); i++) {
             assertTrue(fileText.get(i).equalsIgnoreCase(sampleText.get(i)));
@@ -163,8 +163,7 @@ public class UtilitiesTest {
     public void getFileContentsFromFiles_FilesDoNotExist_ThrowsException() {
         String sampleFilePath1 = Utilities.getConcatPath(new String[] { TestUtilities.getTestResourcesPath(), "text-files", "foo.txt" });
         String sampleFilePath2 = Utilities.getConcatPath(new String[] { TestUtilities.getTestResourcesPath(), "text-files", "bar.txt" });
-        List<File> files = new ArrayList<File>() {
-        };
+        List<File> files = new ArrayList<File>();
         files.add(new File(sampleFilePath1));
         files.add(new File(sampleFilePath2));
         Utilities.getFileContentsFromFiles(files);

--- a/mule-docs-builder/src/test/resources/master-folder/_templates/default.template
+++ b/mule-docs-builder/src/test/resources/master-folder/_templates/default.template
@@ -14,6 +14,7 @@
     <script src="../bootstrap-3.3.4-dist/js/bootstrap.min.js"></script>
     <script src="../js/scripts.js"></script>
     <meta charset="utf-8">
+    {{ page.canonical }}
     {{ page.metadata }}
     {{ page.swifttype-metadata }}
 </head>


### PR DESCRIPTION
* The root of the site should match the URL passed to the docs builder (e.g., https://docs.mulesoft.com)
* The root of a versioned space should have a trailing slash (e.g., https://docs.mulesoft.com/mule-user-guide/v/3.8/)
* The root of a non-versioned space should have a trailing slash (e.g., https://docs.mulesoft.com/quickstarts/)
* All other pages should not have a trailing slash (e.g., https://docs.mulesoft.com/mule-user-guide/v/3.8/installing)